### PR TITLE
CC-6 # add an activity spinner to deploy

### DIFF
--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const elegantSpinner = require('elegant-spinner');
+const logUpdate = require('log-update');
+
 const s3Uploader = require('../lib/s3-uploader');
 const fileList = require('../lib/file-list');
 const fileFilter = require('../lib/file-filter');
@@ -21,6 +24,12 @@ function upload (sourceDir) {
 }
 
 module.exports = function (input, flags, options) {
+  const frame = elegantSpinner();
+  let timer = setInterval(() => {
+    logUpdate(frame());
+  }, 100);
+
   let sourceDir = input[0] || null;
-  return upload(sourceDir);
+  return upload(sourceDir)
+    .then(() => clearTimeout(timer));
 };

--- a/lib/s3-uploader.js
+++ b/lib/s3-uploader.js
@@ -10,7 +10,6 @@ function upload (fileName) {
 
   return s3Factory().then(s3 => {
     return s3.upload({Key: fileName, Body: stream})
-      .on('httpUploadProgress', function (evt) { console.log('upload progress', evt); })
       .send(function (err, data) {
         if (err) {
           console.log(`There was a problem uploading ${fileName} - ${err}`);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
   "dependencies": {
     "@blinkmobile/blinkmrc": "^1.1.0",
     "aws-sdk": "^2.2.36",
+    "elegant-spinner": "1.0.1",
+    "log-update": "1.0.2",
     "meow": "^3.7.0",
     "object-merge": "^2.5.1",
     "update-notifier": "^0.6.0"

--- a/test/file-read-perf.js
+++ b/test/file-read-perf.js
@@ -6,6 +6,9 @@ const pify = require('pify');
 const test = require('ava');
 const temp = require('temp');
 const mockery = require('mockery');
+// require now to avoid mockery warnings
+require('elegant-spinner');
+require('log-update');
 
 const fileData = 'test contents\n\n';
 const pWriteFile = pify(fs.writeFile);
@@ -58,7 +61,10 @@ mockery.registerAllowables([
   '../commands/deploy',
   '../lib/file-list',
   'fs',
-  'path']);
+  'path',
+  'elegant-spinner',
+  'log-update'
+]);
 
 test.after(() => mockery.disable());
 


### PR DESCRIPTION
### Added

- CC-6: show an activity spinner during deploy (#4, @jokeyrhyme)


### Code Review Notes

- also hid the raw console output related to upload progress

- had a discussion with @simonmarklar about how fast this tool is, and how an actual progress bar was probably overkill at this stage

- made sure not to introduce any new mockery warnings